### PR TITLE
Update iso3166-2.json

### DIFF
--- a/src/dataset/iso3166-2.json
+++ b/src/dataset/iso3166-2.json
@@ -7014,7 +7014,7 @@
       "type": "Metropolitan department"
     },
     {
-      "code": "FR-75",
+      "code": "FR-75C",
       "name": "Paris",
       "parent": "IDF",
       "type": "Metropolitan department"
@@ -25601,7 +25601,7 @@
       "type": "Province"
     },
     {
-      "code": "ZA-GT",
+      "code": "ZA-GP",
       "name": "Gauteng",
       "type": "Province"
     },


### PR DESCRIPTION
Fixing 3166-2 codes for Gauteng province in South Africa and Paris in France https://www.iso.org/obp/ui/#iso:code:3166:FR
https://www.iso.org/obp/ui/#iso:code:3166:ZA